### PR TITLE
Add scenario name to benchmark output #8

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -27,7 +27,7 @@ for config in "${CONFIGS[@]}"; do
     read -r size l1 l2 <<< "$config"
     suffix="${size}_${l1}_${l2}"
     for endpoint in "${ENDPOINTS[@]}"; do
-        "${ROOT}/.venv/bin/python" "${DIR}/run_benchmark.py" --endpoint "$endpoint" --filename "benchmark_data_${suffix}.json" --output-file "${ROOT}/results/timing/${endpoint}_${suffix}.yaml" --num-measured "$NUM_MEASURED"
+        "${ROOT}/.venv/bin/python" "${DIR}/run_benchmark.py" --endpoint "$endpoint" --filename "benchmark_data_${suffix}.json" --output-file "${ROOT}/results/timing/${endpoint}_${suffix}.yaml" --num-measured "$NUM_MEASURED" --scenario-name "$suffix"
     done
     "${ROOT}/.venv/bin/python3" "${DIR}/generate_chart.py" "${suffix}" --input-dir "${ROOT}/results/timing" --output "${ROOT}/results/charts/endpoints_${suffix}.png"
 done

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -16,6 +16,7 @@ def run_benchmark(
     endpoint="strawberry_vanilla",
     output_file=None,
     filename="benchmark_data_100_5_5.json",
+    scenario_name=None,
 ):
     print("–––––––––––––––––––––––")
     print(f"Benchmarking {endpoint} with data file {filename}...")
@@ -169,6 +170,7 @@ def run_benchmark(
 
     stats = {
         "endpoint": endpoint,
+        "scenario_name": scenario_name,
         "num_measured": benchmarks,
         "dataset_size": dataset_size,
         "dataset_nested_size": dataset_nested_size,
@@ -229,12 +231,18 @@ if __name__ == "__main__":
         default="benchmark_data_100_5_5.json",
         help="Specific filename to load from sample_data/",
     )
+    parser.add_argument(
+        "--scenario-name",
+        type=str,
+        help="The name of the benchmark scenario",
+    )
     args = parser.parse_args()
 
     run_benchmark(
-        args.num_warmup,
-        args.num_measured,
-        args.endpoint,
-        args.output_file,
-        args.filename,
+        warmups=args.num_warmup,
+        benchmarks=args.num_measured,
+        endpoint=args.endpoint,
+        output_file=args.output_file,
+        filename=args.filename,
+        scenario_name=args.scenario_name,
     )


### PR DESCRIPTION
This PR adds a `scenario_name` key to the benchmark YAML output. 
The `run_benchmark.py` script now accepts an optional `--scenario-name` argument, which is included in the resulting report. 
The `benchmark.sh` script has been updated to automatically pass the data configuration suffix (e.g., `100_5_5`) as the scenario name.

Additionally, the `run_benchmark` function call in `run_benchmark.py` was refactored to use keyword arguments for better maintainability.

fixes #8

---
*PR created automatically by Jules for task [17233397201010343723](https://jules.google.com/task/17233397201010343723) started by @dchaley*